### PR TITLE
support of option "-xmpphost <hostname>"

### DIFF
--- a/apps/s_client.c
+++ b/apps/s_client.c
@@ -407,6 +407,7 @@ static void sc_usage(void)
                "                 only \"smtp\", \"pop3\", \"imap\", \"ftp\", \"xmpp\"\n");
     BIO_printf(bio_err, "                 \"telnet\" and \"ldap\" are supported.\n");
     BIO_printf(bio_err, "                 are supported.\n");
+    BIO_printf(bio_err," -xmpphost host - When used with \"-starttls xmpp\" specifies the virtual host.\n");
 #ifndef OPENSSL_NO_ENGINE
     BIO_printf(bio_err,
                " -engine id    - Initialise and use the specified engine\n");
@@ -675,6 +676,7 @@ int MAIN(int argc, char **argv)
     char *http_proxy_str = NULL, *connect_str = NULL;    
     int full_log = 1;
     char *host = SSL_HOST_NAME;
+    char *xmpphost = NULL;
     char *cert_file = NULL, *key_file = NULL, *chain_file = NULL;
     int cert_format = FORMAT_PEM, key_format = FORMAT_PEM;
     char *passarg = NULL, *pass = NULL;
@@ -806,6 +808,9 @@ int MAIN(int argc, char **argv)
             if (--argc < 1)
                 goto bad;
             http_proxy_str = *(++argv);
+        } else if (strcmp(*argv,"-xmpphost") == 0) {
+           if (--argc < 1) goto bad;
+           xmpphost= *(++argv);
         } else if (strcmp(*argv, "-verify") == 0) {
             verify = SSL_VERIFY_PEER;
             if (--argc < 1)
@@ -1690,7 +1695,7 @@ int MAIN(int argc, char **argv)
         BIO_printf(sbio, "<stream:stream "
                    "xmlns:stream='http://etherx.jabber.org/streams' "
                    "xmlns='jabber:client' to='%s' version='1.0'>",
-                   servername ? servername : host);
+                   xmpphost ? xmpphost : host);
         seen = BIO_read(sbio, mbuf, BUFSIZZ);
         mbuf[seen] = 0;
         while (!strstr

--- a/doc/apps/s_client.pod
+++ b/doc/apps/s_client.pod
@@ -45,6 +45,7 @@ B<openssl> B<s_client>
 [B<-cipher cipherlist>]
 [B<-serverpref>]
 [B<-starttls protocol>]
+[B<-xmpphost hostname>]
 [B<-proxy host:port>]
 [B<-engine id>]
 [B<-tlsextdebug>]
@@ -237,7 +238,13 @@ use the server's cipher preferences; only used for SSLV2.
 
 send the protocol-specific message(s) to switch to TLS for communication.
 B<protocol> is a keyword for the intended protocol.  Currently, the only
-supported keywords are "smtp", "pop3", "imap", and "ftp".
+supported keywords are "smtp", "pop3", "imap", "ftp" and "xmpp".
+
+=item B<-xmpphost hostname>
+
+This option, when used with "-starttls xmpp", specifies the host for the
+"to" attribute of the stream element.  If this option is not specified, 
+then the host specified with "-connect" will be used.
 
 =item B<-proxy host:port>
 


### PR DESCRIPTION

Hi Peter,

jabber needs on a protocol level a hostname.:

Doesn't work: ```openssl s_client -connect talk.google.com:5222 -starttls xmpp```
DOES work:    ```openssl s_client -connect talk.google.com:5222 -starttls xmpp -xmpphost gmail.com```

(probably not very good example as google's IM is not anymore XMPP compatible as I've heard)

This patch adds the option ```-xmpphost <hostname>``` . 

```
prompt|0% echo q | openssl32-static.xmpphost s_client -connect talk.google.com:5222 -starttls xmpp -xmpphost gmail.com 
CONNECTED(00000003)
depth=3 C = US, O = Equifax, OU = Equifax Secure Certificate Authority
verify return:1
depth=2 C = US, O = GeoTrust Inc., CN = GeoTrust Global CA
verify return:1
depth=1 C = US, O = Google Inc, CN = Google Internet Authority G2
verify return:1
depth=0 C = US, ST = California, L = Mountain View, O = Google Inc, CN = gmail.com
verify return:1
---
Certificate chain
 0 s:/C=US/ST=California/L=Mountain View/O=Google Inc/CN=gmail.com
   i:/C=US/O=Google Inc/CN=Google Internet Authority G2
 1 s:/C=US/O=Google Inc/CN=Google Internet Authority G2
   i:/C=US/O=GeoTrust Inc./CN=GeoTrust Global CA
 2 s:/C=US/O=GeoTrust Inc./CN=GeoTrust Global CA
   i:/C=US/O=Equifax/OU=Equifax Secure Certificate Authority
---
Server certificate
-----BEGIN CERTIFICATE-----
MIIEeTCCA2GgAwIBAgIIC0v9l+G/CPowDQYJKoZIhvcNAQEFBQAwSTELMAkGA1UE
BhMCVVMxEzARBgNVBAoTCkdvb2dsZSBJbmMxJTAjBgNVBAMTHEdvb2dsZSBJbnRl
cm5ldCBBdXRob3JpdHkgRzIwHhcNMTUwNjE4MDg1NDUzWhcNMTUwOTE2MDAwMDAw
WjBjMQswCQYDVQQGEwJVUzETMBEGA1UECAwKQ2FsaWZvcm5pYTEWMBQGA1UEBwwN
TW91bnRhaW4gVmlldzETMBEGA1UECgwKR29vZ2xlIEluYzESMBAGA1UEAwwJZ21h
aWwuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAqbf68cb3NnT6
R3IGvodAgijfpKR6iKgjCENQUVXGmItOEjcyNYiUAIhRG6vgZgM84MbNrORkFcM3
++aXGYETNunUPieQwh9tjAlWh8b2xvt4Gtnka2+DA0QSkvCrwSzQIHpSl7bijbrm
saum1B/mSe6+v2bS0RbNmSilvuC1fh8mO6IhGj+Mc3wmAl6JwMF8294alLt+ByPm
Cub25p+XyNZfkTxC80DewffqOPrHFJ9XyoNPTm9racPXf9kKqhWw7A5G6ROUN32x
xfuZCljgBM39VXZ8k1uSwUev7yEOSfb2dEIhhkkTSPNe/NZj//ptismUlJe4Ihmh
yzE9/TZ4HQIDAQABo4IBSTCCAUUwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUF
BwMCMCEGA1UdEQQaMBiCCWdtYWlsLmNvbYILKi5nbWFpbC5jb20waAYIKwYBBQUH
AQEEXDBaMCsGCCsGAQUFBzAChh9odHRwOi8vcGtpLmdvb2dsZS5jb20vR0lBRzIu
Y3J0MCsGCCsGAQUFBzABhh9odHRwOi8vY2xpZW50czEuZ29vZ2xlLmNvbS9vY3Nw
MB0GA1UdDgQWBBRtRI8rHBK2jIZUmv8kDbbskUDE/zAMBgNVHRMBAf8EAjAAMB8G
A1UdIwQYMBaAFErdBhYbvPZotXb1gba7Yhq6WoEvMBcGA1UdIAQQMA4wDAYKKwYB
BAHWeQIFATAwBgNVHR8EKTAnMCWgI6Ahhh9odHRwOi8vcGtpLmdvb2dsZS5jb20v
R0lBRzIuY3JsMA0GCSqGSIb3DQEBBQUAA4IBAQA2KMmUXVVbTPCqnJXWED/85gkZ
WWssZ3OL56hpUHsQM28hrapHWrd754e1iC96Q8FiWRYtd1hIRZf/UceO3ios085j
Aq8vobg2cv7mMf4uUXIfpdEErBGvZnnETld4hElNGv4N2GhN8M9T+9mX8k6lu3r1
Ad1nq0U9mZ+jNM9CvHbXHjHFuKZ4tjoyTF86i03r57iiI/Cl4ag1+Ydr4JF89FoD
NxQdIOamhh3Zv28TwW5yRukSCOCqp1tflBOrpCFH8BU5PXohovwIGJAugTEFIMQB
53+AfO3ZehhIb7aSwENW35lDkp1ut0BanLvqs7vbyAm88pjRPo+9fXQLiGEE
-----END CERTIFICATE-----
subject=/C=US/ST=California/L=Mountain View/O=Google Inc/CN=gmail.com
issuer=/C=US/O=Google Inc/CN=Google Internet Authority G2
---
No client certificate CA names sent
Peer signing digest: SHA512
Server Temp Key: ECDH, P-256, 256 bits
---
SSL handshake has read 4143 bytes and written 653 bytes
---
New, TLSv1/SSLv3, Cipher is ECDHE-RSA-CHACHA20-POLY1305
Server public key is 2048 bit
Secure Renegotiation IS supported
Compression: NONE
Expansion: NONE
No ALPN negotiated
SSL-Session:
    Protocol  : TLSv1.2
    Cipher    : ECDHE-RSA-CHACHA20-POLY1305
    Session-ID: F8715837B3A5FF071BE14CC0526CDE39F86D9C14E6398D741D736A737FC93B3B
    Session-ID-ctx: 
    Master-Key: 1DE779C6A07F9674E7E29259D99EDC200258191240360DB0BE795A2A3745E788F48186E7429FE25A2F18945A51AF41AA
    Key-Arg   : None
    PSK identity: None
    PSK identity hint: None
    SRP username: None
    TLS session ticket lifetime hint: 100800 (seconds)
    TLS session ticket:
    0000 - 6d 23 01 58 da ca 82 21-fd 42 bf e7 42 4a b1 0f   m#.X...!.B..BJ..
    0010 - 67 e6 a2 83 1d 87 e9 e1-0d 40 52 8a 60 4b bd 4b   g........@R.`K.K
    0020 - 74 e9 01 1b 8d c5 a9 62-cc f7 78 83 24 7d a9 38   t......b..x.$}.8
    0030 - fe 70 77 3c 65 aa cc 2b-0b 68 5d 5b b5 81 9b f2   .pw<e..+.h][....
    0040 - a5 57 d6 23 9d bc 84 57-6a 68 08 46 92 90 6d a1   .W.#...Wjh.F..m.
    0050 - de 9d d1 52 c6 e8 ba 32-f1 bf bc 51 7d 93 fd e8   ...R...2...Q}...
    0060 - 30 55 0c e8 c9 aa 61 d9-8c d4 0e 14 59 fe b9 5f   0U....a.....Y.._
    0070 - 96 3e f7 00 47 a7 15 13-13 52 0e f0 64 47 cd 19   .>..G....R..dG..
    0080 - a5 32 ec c2 c6 f9 b1 14-48 62 cd 0f 00 c7 07 0f   .2......Hb......
    0090 - bc aa 5b 5b d1 53 bd 10-1c 59 60 78 10 38 c8 b3   ..[[.S...Y`x.8..
    00a0 - 69 da 08 8d                                       i...

    Start Time: 1436200688
    Timeout   : 300 (sec)
    Verify return code: 0 (ok)
---
DONE
prompt|0% 
```

Source: http://t126982.encryption-openssl-cvs.encryptiontalk.info/openssl-source-code-branch-master-updated-d2625fd65772ce3de2563e648decd2d1074fd873-t126982.html . Newer branch: https://mta.openssl.org/pipermail/openssl-commits/2015-April/000947.html .

Cheers, Dirk
