### PR TITLE
Ensure openssl builds on systems not having `makedepend`.

### DIFF
--- a/Configure
+++ b/Configure
@@ -7,7 +7,6 @@ eval 'exec perl -S $0 ${1+"$@"}'
 
 require 5.000;
 use strict;
-use File::Which;
 
 # see INSTALL for instructions.
 
@@ -1675,7 +1674,15 @@ if ($strict_warnings)
 		}
 	}
 
-my $makedepend_exe_path = which('makedepend');
+# http://perldoc.perl.org/perlop.html#Quote-Like-Operators
+# ensure to take the stdout and stderror so we get output like this:
+# 'makedepend: error:  cannot open "Makefile.makedepend" 
+#'.
+my $makedepend_output = `makedepend -f Makefile.makedepend 2>&1`;
+if (!$makedepend_output)
+  {
+  print "No makedepend executable found on your path.\n";
+  }
 
 open(IN,'<Makefile.org') || die "unable to read Makefile.org:$!\n";
 unlink("$Makefile.new") || die "unable to remove old $Makefile.new:$!\n" if -e "$Makefile.new";
@@ -1726,7 +1733,7 @@ while (<IN>)
 		s/^RANLIB=.*/RANLIB= $ranlib/;
 		s/^MAKEDEPPROG=.*$/MAKEDEPPROG= $cc/ if $cc eq "gcc";
 		}
-	if ($makedepend_exe_path eq "")
+	if (!$makedepend_output)
 		{
 		s/^MAKEDEPPROG=\s*makedepend.*$/MAKEDEPPROG= \$\(CC\) -v -M/;
 		}

--- a/Configure
+++ b/Configure
@@ -7,6 +7,7 @@ eval 'exec perl -S $0 ${1+"$@"}'
 
 require 5.000;
 use strict;
+use File::Which;
 
 # see INSTALL for instructions.
 
@@ -1674,6 +1675,8 @@ if ($strict_warnings)
 		}
 	}
 
+my $makedepend_exe_path = which('makedepend');
+
 open(IN,'<Makefile.org') || die "unable to read Makefile.org:$!\n";
 unlink("$Makefile.new") || die "unable to remove old $Makefile.new:$!\n" if -e "$Makefile.new";
 open(OUT,">$Makefile.new") || die "unable to create $Makefile.new:$!\n";
@@ -1722,6 +1725,10 @@ while (<IN>)
 		s/^AR=\s*ar/AR= $ar/;
 		s/^RANLIB=.*/RANLIB= $ranlib/;
 		s/^MAKEDEPPROG=.*$/MAKEDEPPROG= $cc/ if $cc eq "gcc";
+		}
+	if ($makedepend_exe_path eq "")
+		{
+		s/^MAKEDEPPROG=\s*makedepend.*$/MAKEDEPPROG= \$\(CC\) -v -M/;
 		}
 	s/^CFLAG=.*$/CFLAG= $cflags/;
 	s/^DEPFLAG=.*$/DEPFLAG=$depflags/;

--- a/util/domd
+++ b/util/domd
@@ -14,7 +14,7 @@ if [ "$MAKEDEPEND" = "" ]; then MAKEDEPEND=makedepend; fi
 cp Makefile Makefile.save
 # fake the presence of Kerberos
 touch $TOP/krb5.h
-if expr "$MAKEDEPEND" : '.*gcc$' > /dev/null; then
+if expr "$MAKEDEPEND" : '.*cc$' > /dev/null; then
     args=""
     while [ $# -gt 0 ]; do
 	if [ "$1" != "--" ]; then args="$args $1"; fi


### PR DESCRIPTION
Solves issues when building on darwin which doesn't have `makedepend`.