### PR TITLE
Fix VC9 x86 build: declaration at begin of block

### DIFF
--- a/crypto/evp/e_chacha20poly1305.c
+++ b/crypto/evp/e_chacha20poly1305.c
@@ -133,6 +133,7 @@ static ossl_ssize_t aead_chacha20_poly1305_seal(const EVP_AEAD_CTX *ctx,
 {
     const struct aead_chacha20_poly1305_ctx *c20_ctx = ctx->aead_state;
     unsigned char poly1305_key[32];
+    unsigned char tag[POLY1305_TAG_LEN];
     poly1305_state poly1305;
     const uint64_t in_len_64 = in_len;
 
@@ -174,7 +175,6 @@ static ossl_ssize_t aead_chacha20_poly1305_seal(const EVP_AEAD_CTX *ctx,
     CRYPTO_chacha_20(out, in, in_len, c20_ctx->key, nonce, 1);
     poly1305_update_with_length(&poly1305, out, in_len);
 
-    unsigned char tag[POLY1305_TAG_LEN];
     CRYPTO_poly1305_finish(&poly1305, tag);
     memcpy(out + in_len, tag, c20_ctx->tag_len);
     return in_len + c20_ctx->tag_len;


### PR DESCRIPTION
See https://www.apachelounge.com/viewtopic.php?p=32641#32641 for the use case. The only known 256-bits cipher for http/2. Sadly enough only supported in Chrome.