### PR TITLE
Fix invalid reference to ERR_raise introduced in 4c0a0b8

### DIFF
--- a/crypto/bn/bn_sqrt.c
+++ b/crypto/bn/bn_sqrt.c
@@ -365,7 +365,7 @@ BIGNUM *BN_mod_sqrt(BIGNUM *in, const BIGNUM *a, const BIGNUM *p, BN_CTX *ctx)
         }
         /* If not found, a is not a square or p is not prime. */
         if (i >= e) {
-            ERR_raise(ERR_LIB_BN, BN_R_NOT_A_SQUARE);
+            BNerr(BN_F_BN_MOD_SQRT, BN_R_NOT_A_SQUARE);
             goto end;
         }
 


### PR DESCRIPTION
The right call seems to be [to BNerr](https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=3118eb64934499d93db3230748a452351d1d9a65) rather than [ERR_raise](https://git.openssl.org/gitweb/?p=openssl.git;a=commitdiff;h=a466912611aa6cbdf550cd10601390e587451246) which does not exist in this version and causes the build to fail. I have never worked on OpenSSL before though.